### PR TITLE
Fix Windows compilation issues

### DIFF
--- a/include/ReiseManager/Core/Trip.hpp
+++ b/include/ReiseManager/Core/Trip.hpp
@@ -16,6 +16,9 @@ public:
      */
     struct SDNumber { std::string sd; std::string position; };
 
+    /** Default construct an empty Trip. */
+    Trip();
+
     /** Construct a new Trip with all metadata. */
     Trip(const SDNumber& sdnum, const std::string& title, const std::string& machine,
          const std::string& company, const std::string& location,

--- a/src/Core/Trip.cpp
+++ b/src/Core/Trip.cpp
@@ -31,6 +31,11 @@ static void UnixTimeToFileTime(std::time_t t, FILETIME *ft)
 }
 #endif
 
+Trip::Trip()
+    : start_(std::chrono::system_clock::now()), end_(start_)
+{
+}
+
 Trip::Trip(const SDNumber &sdnum, const std::string &title, const std::string &machine,
            const std::string &company, const std::string &location,
            const std::chrono::system_clock::time_point &start,
@@ -167,7 +172,7 @@ void Trip::ApplyToShortcut(const std::filesystem::path &shortcutPath) const
         wchar_t dur[32];
         swprintf(dur, 32, L"%d Tage", GetDuration());
         InitPropVariantFromString(dur, &pv);
-        store->SetValue(PKEY_Duration, pv);
+        store->SetValue(PKEY_Calendar_Duration, pv);
         PropVariantClear(&pv);
         store->Commit();
         store->Release();

--- a/src/UI/TripDialog.cpp
+++ b/src/UI/TripDialog.cpp
@@ -49,11 +49,12 @@ int TripDialog::Show(HINSTANCE hInstance, HWND hParent)
                 dlg = reinterpret_cast<TripDialog *>(cs->lpCreateParams);
                 SetWindowLongPtrW(hWnd, GWLP_USERDATA, (LONG_PTR)dlg);
                 dlg->hwnd_ = hWnd;
+                HINSTANCE hInst = cs->hInstance;
                 int y = 10;
                 auto makeLabel = [&](int id, const wchar_t *text)
-                { CreateWindowW(L"STATIC", text, WS_CHILD | WS_VISIBLE, 10, y, 80, 20, hWnd, (HMENU)id, hInstance, nullptr); };
+                { CreateWindowW(L"STATIC", text, WS_CHILD | WS_VISIBLE, 10, y, 80, 20, hWnd, (HMENU)id, hInst, nullptr); };
                 auto makeEdit = [&](int id, const wchar_t *txt)
-                {HWND h=CreateWindowExW(WS_EX_CLIENTEDGE,L"EDIT",txt,WS_CHILD|WS_VISIBLE|ES_AUTOHSCROLL,100,y,200,20,hWnd,(HMENU)id,hInstance,nullptr);y+=25;return h; };
+                {HWND h=CreateWindowExW(WS_EX_CLIENTEDGE,L"EDIT",txt,WS_CHILD|WS_VISIBLE|ES_AUTOHSCROLL,100,y,200,20,hWnd,(HMENU)id,hInst,nullptr);y+=25;return h; };
                 makeLabel(1, L"SD");
                 dlg->edSd_ = makeEdit(101, dlg->modeNew_ ? L"" : std::wstring(dlg->trip_.GetSDNumber().sd.begin(), dlg->trip_.GetSDNumber().sd.end()).c_str());
                 makeLabel(2, L"Pos");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
             std::filesystem::create_directory(tripFolder);
             SetFileAttributesW(tripFolder.wstring().c_str(), FILE_ATTRIBUTE_HIDDEN);
             ReiseManager::Core::Log("INFO", "Created folder " + tripFolder.string());
-            auto linkPath = rootPath / (folderName + L".lnk");
+            std::filesystem::path linkPath = rootPath / folderName;
+            linkPath.replace_extension(L".lnk");
             trip.ApplyToShortcut(linkPath);
             ReiseManager::Core::Log("INFO", "Wrote shortcut " + linkPath.string());
         }
@@ -78,7 +79,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
                 std::filesystem::rename(old, newFolder);
                 ReiseManager::Core::Log("INFO", "Renamed folder to " + newFolder.string());
             }
-            auto newLink = rootPath / (folderName + L".lnk");
+            std::filesystem::path newLink = rootPath / folderName;
+            newLink.replace_extension(L".lnk");
             if (oldLink != newLink && std::filesystem::exists(oldLink))
             {
                 std::filesystem::rename(oldLink, newLink);


### PR DESCRIPTION
## Summary
- add default constructor for `Trip`
- use correct calendar duration property key
- remove usage of external capture of `hInstance` in TripDialog window procedure
- construct shortcut paths via `replace_extension`

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6889bb11f9f4832dbb5229c9ab03aad8