### PR TITLE
Enable multi-user NSIS installer via CPack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,16 +17,6 @@ if(NOT CMAKE_INSTALL_PREFIX)
     set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install" CACHE PATH "Installation Directory" FORCE)
 endif()
  
-# Installer target: build NSIS installer if makensis is found
-find_program(NSIS_COMPILER makensis)
-if(NSIS_COMPILER)
-    add_custom_target(installer
-        COMMENT "Building NSIS installer"
-        COMMAND "${NSIS_COMPILER}" "${CMAKE_SOURCE_DIR}/installer/installer.nsi"
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
-else()
-    message(WARNING "makensis not found. Installer target will not be available.")
-endif()
 include(GNUInstallDirs)
 
 # Include directories
@@ -66,4 +56,5 @@ set(CPACK_NSIS_MUI_UNIICON "${CMAKE_SOURCE_DIR}/resources/Reise.ico")
 set(CPACK_NSIS_DISPLAY_NAME "${PROJECT_NAME}")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "${PROJECT_NAME}")
 set(CPACK_MONOLITHIC_INSTALL ON)
+set(CPACK_NSIS_TEMPLATE "${CMAKE_SOURCE_DIR}/installer/installer.nsi")
 include(CPack)

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -1,20 +1,42 @@
 !define APP_NAME "ReiseManager"
 !define APP_EXE "ReiseManager.exe"
-!define INSTALL_DIR_REGKEY "HKCU\\Software\\ReiseManager"
+!define INSTALL_DIR_REGKEY "Software\\ReiseManager"
 !define INSTALL_DIR_REGVALUE "InstallPath"
 !define ROOT_DIR_REGVALUE "RootReisenPath"
+
+!define MULTIUSER_MUI
+!define MULTIUSER_EXECUTIONLEVEL Highest
+!define MULTIUSER_INSTALLMODE_INSTDIR "${APP_NAME}"
+!define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_KEY "${INSTALL_DIR_REGKEY}"
+!define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_VALUENAME "${INSTALL_DIR_REGVALUE}"
+
+!include "MUI2.nsh"
+!include "MultiUser.nsh"
+!include "LogicLib.nsh"
+!include "nsDialogs.nsh"
 
 Outfile "${APP_NAME}Setup.exe"
 Icon "..\\resources\\Reise.ico"
 UninstallIcon "..\\resources\\Reise.ico"
-InstallDir $LOCALAPPDATA\\${APP_NAME}
-RequestExecutionLevel user
+InstallDir "$LOCALAPPDATA\\${APP_NAME}"
 
+!insertmacro MULTIUSER_PAGE_INSTALLMODE
+!insertmacro MUI_PAGE_DIRECTORY
 Page custom SelectRootFolder
-Page directory
-Page instfiles
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_LANGUAGE "German"
 
 Var ReisenRoot
+
+Function .onInit
+    !insertmacro MULTIUSER_INIT
+FunctionEnd
+
+Function un.onInit
+    !insertmacro MULTIUSER_UNINIT
+FunctionEnd
 
 Function SelectRootFolder
     nsDialogs::SelectFolderDialog "Wählen Sie den Reisen-Ordner" "$PROFILE"
@@ -28,39 +50,39 @@ FunctionEnd
 Section "Install"
     SetOutPath "$INSTDIR"
     File /r "bin\\*"
-    WriteRegStr HKCU "Software\\ReiseManager" "${INSTALL_DIR_REGVALUE}" "$INSTDIR"
-    WriteRegStr HKCU "Software\\ReiseManager" "${ROOT_DIR_REGVALUE}" "$ReisenRoot"
+    WriteRegStr ShCtx "${INSTALL_DIR_REGKEY}" "${INSTALL_DIR_REGVALUE}" "$INSTDIR"
+    WriteRegStr ShCtx "${INSTALL_DIR_REGKEY}" "${ROOT_DIR_REGVALUE}" "$ReisenRoot"
 
     ; create uninstaller
     WriteUninstaller "$INSTDIR\\Uninstall.exe"
-    WriteRegStr HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ReiseManager" "DisplayName" "ReiseManager"
-    WriteRegStr HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ReiseManager" "UninstallString" "$INSTDIR\\Uninstall.exe"
+    WriteRegStr ShCtx "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ReiseManager" "DisplayName" "ReiseManager"
+    WriteRegStr ShCtx "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ReiseManager" "UninstallString" "$INSTDIR\\Uninstall.exe"
 
     ; context menu "Neue Reise"
-    WriteRegStr HKCU "Software\\Classes\\Directory\\shell\\ReiseManager.New" "" "Neue Reise erstellen"
-    WriteRegStr HKCU "Software\\Classes\\Directory\\shell\\ReiseManager.New" "AppliesTo" "System.ItemPathDisplay:='$ReisenRoot'"
-    WriteRegStr HKCU "Software\\Classes\\Directory\\shell\\ReiseManager.New\\command" "" '"$INSTDIR\\${APP_EXE}" --new'
+    WriteRegStr ShCtx "Software\\Classes\\Directory\\shell\\ReiseManager.New" "" "Neue Reise erstellen"
+    WriteRegStr ShCtx "Software\\Classes\\Directory\\shell\\ReiseManager.New" "AppliesTo" "System.ItemPathDisplay:='$ReisenRoot'"
+    WriteRegStr ShCtx "Software\\Classes\\Directory\\shell\\ReiseManager.New\\command" "" '"$INSTDIR\\${APP_EXE}" --new'
 
     ; context menu "Reise bearbeiten" for folders
-    WriteRegStr HKCU "Software\\Classes\\Directory\\shell\\ReiseManager.Edit" "" "Reise bearbeiten"
-    WriteRegStr HKCU "Software\\Classes\\Directory\\shell\\ReiseManager.Edit" "AppliesTo" "System.ItemPathDisplay:='$ReisenRoot\\*'"
-    WriteRegStr HKCU "Software\\Classes\\Directory\\shell\\ReiseManager.Edit\\command" "" '"$INSTDIR\\${APP_EXE}" --edit "%1"'
+    WriteRegStr ShCtx "Software\\Classes\\Directory\\shell\\ReiseManager.Edit" "" "Reise bearbeiten"
+    WriteRegStr ShCtx "Software\\Classes\\Directory\\shell\\ReiseManager.Edit" "AppliesTo" "System.ItemPathDisplay:='$ReisenRoot\\*'"
+    WriteRegStr ShCtx "Software\\Classes\\Directory\\shell\\ReiseManager.Edit\\command" "" '"$INSTDIR\\${APP_EXE}" --edit "%1"'
     ; for lnk files
-    WriteRegStr HKCU "Software\\Classes\\lnkfile\\shell\\ReiseManager.Edit" "" "Reise bearbeiten"
-    WriteRegStr HKCU "Software\\Classes\\lnkfile\\shell\\ReiseManager.Edit\\command" "" '"$INSTDIR\\${APP_EXE}" --edit "%1"'
+    WriteRegStr ShCtx "Software\\Classes\\lnkfile\\shell\\ReiseManager.Edit" "" "Reise bearbeiten"
+    WriteRegStr ShCtx "Software\\Classes\\lnkfile\\shell\\ReiseManager.Edit\\command" "" '"$INSTDIR\\${APP_EXE}" --edit "%1"'
 
     ; custom columns for Reisen folder
-    WriteRegStr HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FolderTypes\\{8AA0F2C2-7F91-4F62-BF55-3D2C3AA7EBDC}" "Name" "Reisen"
-    WriteRegStr HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FolderTypes\\{8AA0F2C2-7F91-4F62-BF55-3D2C3AA7EBDC}\\TopViews\\{00000000-0000-0000-0000-000000000000}" "ColumnList" "prop:System.ItemNameDisplay;System.Title;System.Company;System.Category;System.Calendar.Location;System.Duration;System.StartDate;System.EndDate;System.DateCreated"
+    WriteRegStr ShCtx "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FolderTypes\\{8AA0F2C2-7F91-4F62-BF55-3D2C3AA7EBDC}" "Name" "Reisen"
+    WriteRegStr ShCtx "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FolderTypes\\{8AA0F2C2-7F91-4F62-BF55-3D2C3AA7EBDC}\\TopViews\\{00000000-0000-0000-0000-000000000000}" "ColumnList" "prop:System.ItemNameDisplay;System.Title;System.Company;System.Category;System.Calendar.Location;System.Duration;System.StartDate;System.EndDate;System.DateCreated"
 SectionEnd
 
 Section "Uninstall"
-    DeleteRegKey HKCU "Software\\Classes\\Directory\\shell\\ReiseManager.New"
-    DeleteRegKey HKCU "Software\\Classes\\Directory\\shell\\ReiseManager.Edit"
-    DeleteRegKey HKCU "Software\\Classes\\lnkfile\\shell\\ReiseManager.Edit"
-    DeleteRegKey HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FolderTypes\\{8AA0F2C2-7F91-4F62-BF55-3D2C3AA7EBDC}"
-    DeleteRegKey HKCU "Software\\ReiseManager"
-    DeleteRegKey HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ReiseManager"
+    DeleteRegKey ShCtx "Software\\Classes\\Directory\\shell\\ReiseManager.New"
+    DeleteRegKey ShCtx "Software\\Classes\\Directory\\shell\\ReiseManager.Edit"
+    DeleteRegKey ShCtx "Software\\Classes\\lnkfile\\shell\\ReiseManager.Edit"
+    DeleteRegKey ShCtx "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FolderTypes\\{8AA0F2C2-7F91-4F62-BF55-3D2C3AA7EBDC}"
+    DeleteRegKey ShCtx "${INSTALL_DIR_REGKEY}"
+    DeleteRegKey ShCtx "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ReiseManager"
     Delete "$INSTDIR\\Uninstall.exe"
     RMDir /r "$INSTDIR"
 SectionEnd


### PR DESCRIPTION
## Summary
- move installer logic into CPack
- update NSIS template with MultiUser support
- show Reisen folder selection after install directory

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`
- `cpack --config build/CPackConfig.cmake -G NSIS`

------
https://chatgpt.com/codex/tasks/task_e_688b31d94d38832d8192573472681661