### PR TITLE
Configure CPack with Inno Setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,16 +52,3 @@ set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(CPACK_PROJECT_CONFIG_FILE "${CMAKE_SOURCE_DIR}/installer/cpack_inno_config.cmake")
 include(CPack)
-
-if(CMAKE_CONFIGURATION_TYPES)
-    set(CPACK_CONFIG_ARG "-C $<CONFIG>")
-else()
-    set(CPACK_CONFIG_ARG "")
-endif()
-
-add_custom_target(installer
-    COMMAND "${CMAKE_CPACK_COMMAND}" ${CPACK_CONFIG_ARG}
-            -D CPACK_GENERATOR=External
-            -D CPACK_PROJECT_CONFIG_FILE=${CMAKE_SOURCE_DIR}/installer/cpack_inno_config.cmake
-    COMMENT "Generate TravelManager Setup.exe"
-)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -93,14 +93,6 @@
       "configurePreset": "windows-ninja"
     },
     {
-      "name": "windows-ninja-installer",
-      "displayName": "Installer",
-      "inherits": "windows-ninja-release",
-      "targets": [
-        "installer"
-      ]
-    },
-    {
       "name": "windows-vs-debug",
       "displayName": "Debug",
       "configuration": "Debug",
@@ -141,10 +133,13 @@
   ],
   "packagePresets": [
     {
-      "name": "Inno Setup",
+      "name": "windows-ninja-installer",
       "displayName": "Installer",
       "configurePreset": "windows-ninja",
-      "description": "Creates TravelManagerSetup.exe"
+      "description": "Creates TravelManagerSetup.exe",
+      "configurations": [
+        "Release"
+      ]
     }
   ],
   "workflowPresets": [
@@ -159,10 +154,6 @@
         {
           "type": "build",
           "name": "windows-ninja-release"
-        },
-        {
-          "type": "build",
-          "name": "windows-ninja-installer"
         },
         {
           "type": "package",

--- a/installer/cpack_inno_config.cmake
+++ b/installer/cpack_inno_config.cmake
@@ -1,0 +1,12 @@
+# CPack configuration for Inno Setup
+set(CPACK_GENERATOR "INNO")
+
+if(WIN32)
+  find_program(CPACK_INNOSETUP_ISCC iscc HINTS "$ENV{ProgramFiles(x86)}/Inno Setup 6" "$ENV{ProgramFiles}/Inno Setup 6" REQUIRED)
+else()
+  # Allow configuration on non-Windows hosts where iscc is unavailable
+  set(CPACK_INNOSETUP_ISCC iscc)
+endif()
+
+set(CPACK_INNOSETUP_SCRIPT "${CMAKE_SOURCE_DIR}/installer/inno_installer.iss")
+file(TO_NATIVE_PATH "${CMAKE_SOURCE_DIR}/resources/Travel.ico" CPACK_INNOSETUP_ICON_FILE)

--- a/installer/inno_installer.iss
+++ b/installer/inno_installer.iss
@@ -8,9 +8,9 @@
 ;   Uninstaller removes registry keys & Desktop.ini
 ; ============================================================
 
-#define MyAppName     "TravelManager"
+#define MyAppName     "@CPACK_PACKAGE_NAME@"
 #define MyAppExeName  "TravelManager.exe"
-#define MyAppVersion  "0.1"
+#define MyAppVersion  "@CPACK_PACKAGE_VERSION@"
 
 ; ---------------------------------------------------------------------------
 ;  SETUP
@@ -20,8 +20,8 @@ AppName                      = {#MyAppName}
 AppVersion                   = {#MyAppVersion}
 DefaultDirName               = {code:GetInstallDir}
 DefaultGroupName             = {#MyAppName}
-OutputBaseFilename           = TravelManagerSetup
-SetupIconFile                = ..\resources\Travel.ico
+OutputBaseFilename           = @CPACK_PACKAGE_FILE_NAME@
+SetupIconFile                = @CPACK_INNOSETUP_ICON_FILE@
 Compression                  = lzma
 SolidCompression             = yes
 
@@ -33,7 +33,7 @@ PrivilegesRequiredOverridesAllowed = dialog
 ;  FILES & RUN
 ; ---------------------------------------------------------------------------
 [Files]
-Source: "..\install\*"; DestDir: "{app}"; Flags: recursesubdirs
+Source: "@CPACK_TEMPORARY_INSTALL_DIRECTORY@\*"; DestDir: "{app}"; Flags: recursesubdirs
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "Launch TravelManager"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary
- integrate dedicated CPack config to drive Inno Setup compiler
- streamline CMake presets and workflow for packaging
- update installer script to use CPack-provided variables

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`
- `cpack --preset windows-ninja-installer` *(falls back to default generators on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_688f174dff78832d88d62c1f74e5d581